### PR TITLE
Add blacklight_heatmaps:index:seed_random rake task

### DIFF
--- a/lib/tasks/blacklight_heatmaps_tasks.rake
+++ b/lib/tasks/blacklight_heatmaps_tasks.rake
@@ -8,5 +8,14 @@ namespace :blacklight_heatmaps do
       conn.add docs
       conn.commit
     end
+
+    desc 'Fetch random data from WhosOnFirst gazetteer and seed into Solr'
+    task :seed_random, [:n] => [:environment] do |_t, args|
+      args.with_defaults(n: 10)
+      docs = YAML.load(`bundle exec ruby #{File.join(BlacklightHeatmaps::Engine.root, 'scripts', 'sample_whosonfirst.rb')} #{args[:n]}`)
+      conn = Blacklight.default_index.connection
+      conn.add docs
+      conn.commit
+    end
   end
 end

--- a/scripts/sample_whosonfirst.rb
+++ b/scripts/sample_whosonfirst.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+
+# TODO: Needs MAJOR cleanup
+
+require 'open-uri'
+require 'json'
+require 'yaml'
+
+class SampleWhosonfirst
+  # https://whosonfirst.mapzen.com/spelunker/random
+  # Redirects to an HTML page with the following GeoJSON link:
+  #   <a href="/data/722/781/341/722781341.geojson" target="data">Raw data (GeoJSON)</a>
+  def self.random_place
+    open('https://whosonfirst.mapzen.com/spelunker/random') do |f|
+      html = f.read
+      if html =~ /\<a href="(\/data\/\d+\/\d+\/\d+\/\d+\.geojson)" target="data"/
+        return JSON.parse(open('https://whosonfirst.mapzen.com' + Regexp.last_match(1)).read)
+      end
+    end
+    nil
+  rescue OpenURI::HTTPError
+    nil
+  end
+
+  def self.to_solr(place)
+    doc = {}
+    return doc if place.nil?
+    props = place['properties']
+    # puts place.to_yaml
+
+    doc['id'] = place['id']
+
+    doc['title_display'] = props['wof:name']
+
+    doc['subject_geo_facet'] = []
+    doc['subject_geo_facet'] << props['qs:a0'] unless props['qs:a0'].nil?
+    doc['subject_geo_facet'] << props['sg:province'] unless props['sg:province'].nil?
+    doc['subject_geo_facet'] << props['wof:country'] unless props['wof:country'].nil?
+
+    doc['subject_topic_facet'] = []
+    doc['subject_topic_facet'] << props['wof:placetype'] unless props['wof:placetype'].nil?
+    doc['subject_topic_facet'] << props['sg:classifiers'].first['category'] unless props['sg:classifiers'].nil? || props['sg:classifiers'].first.nil?
+
+    doc['geo_srpt'] = case place['geometry']['type']
+    when 'Point'
+      [props['geom:longitude'], props['geom:latitude']].join(' ')
+    when 'Polygon'
+      west, south, east, north = props['geom:bbox'].split(',')
+      "ENVELOPE(#{west}, #{east}, #{north}, #{south})"
+    else
+      fail "Unknown Geometry Type: #{place['geometry']['type']}"
+    end
+    doc
+  end
+end
+
+(ARGV.first || 1).to_i.times do |i|
+  puts SampleWhosonfirst.to_solr(SampleWhosonfirst.random_place).to_yaml
+end
+
+# Some good sample data:
+# puts SampleWhosonfirst.to_solr(JSON.parse(open('https://whosonfirst.mapzen.com/data/101/720/229/101720229.geojson').read)).to_yaml
+# puts SampleWhosonfirst.to_solr(JSON.parse(open('https://whosonfirst.mapzen.com/data/639/115/859/639115859.geojson').read)).to_yaml


### PR DESCRIPTION
This PR is connected to #4 by adding a rake task `blacklight_heatmaps:index:seed_random` that will generate a random set of Solr documents, all of which have location information, and load them into the Solr instance. It uses the Who's on first gazetteer website for this.

Usage:

```
bundle exec rake blacklight_heatmaps:index:seed_random # defaults to 10
bundle exec rake blacklight_heatmaps:index:seed_random[100]
```

sample YAML output:

```
% bundle exec ruby scripts/sample_whosonfirst.rb  

---
id: 873960949
title_display: Rf Phantom Inc
subject_geo_facet:
- NE
- US
subject_topic_facet:
- venue
- Bars & Pubs
geo_srpt: "-95.955026 41.109621"
```
