### PR TITLE
spelunker sometimes is missing an ID value

### DIFF
--- a/scripts/sample_whosonfirst.rb
+++ b/scripts/sample_whosonfirst.rb
@@ -33,7 +33,7 @@ class Place
     props = place['properties']
     # puts place.to_yaml
 
-    fail if place['id'].nil?
+    fail 'Missing ID' if place['id'].to_s.empty? # spelunker sometimes is missing an ID value -- dunno why
     doc['id'] = place['id']
 
     doc['title_display'] = props['wof:name']


### PR DESCRIPTION
This PR is connected to #4. Fixes a data error when id value is missing/blank
