### PR TITLE
make datafile an optional argument for blacklight_heatmaps:index:seed

### DIFF
--- a/lib/tasks/blacklight_heatmaps_tasks.rake
+++ b/lib/tasks/blacklight_heatmaps_tasks.rake
@@ -2,16 +2,20 @@
 namespace :blacklight_heatmaps do
   namespace :index do
     desc 'Put sample data into Solr'
-    task seed: [:environment] do
-      docs = YAML.load(File.open(File.join(BlacklightHeatmaps::Engine.root, 'solr', 'sample_solr_documents.yml')))
+    task :seed, [:datafile] => [:environment] do |_t, args|
+      args.with_defaults(datafile: 'sample_solr_documents')
+      fn = File.join(BlacklightHeatmaps::Engine.root, 'solr', args[:datafile] + '.yml')
+      puts "Indexing sample data from #{fn}"
+      docs = YAML.load(File.open(fn))
       conn = Blacklight.default_index.connection
       conn.add docs
       conn.commit
     end
 
-    desc 'Fetch random data from WhosOnFirst gazetteer and seed into Solr'
+    desc 'Fetch random data from WhosOnFirst gazetteer and index into Solr'
     task :seed_random, [:n] => [:environment] do |_t, args|
       args.with_defaults(n: 10)
+      puts "Indexing #{args[:n]} random data records"
       docs = YAML.load(`bundle exec ruby #{File.join(BlacklightHeatmaps::Engine.root, 'scripts', 'sample_whosonfirst.rb')} #{args[:n]}`)
       conn = Blacklight.default_index.connection
       conn.add docs


### PR DESCRIPTION
This PR adds an optional argument to the `blacklight_heatmaps:index:seed` task so that you can provide the data file as an argument.

Usage from the `.internal_test_app` folder:

```
% bundle exec rake blacklight_heatmaps:index:seed
Indexing sample data from /Users/drh/workspace/blacklight_heatmaps/solr/sample_solr_documents.yml
% bundle exec rake blacklight_heatmaps:index:seed[sample_solr_documents_random_1000]
Indexing sample data from /Users/drh/workspace/blacklight_heatmaps/solr/sample_solr_documents_random_1000.yml
```
