### PR TITLE
Adds support for Solr's heatmap.distErrPct paramater.

### DIFF
--- a/app/models/concerns/blacklight_heatmaps/solr_facet_heatmap_behavior.rb
+++ b/app/models/concerns/blacklight_heatmaps/solr_facet_heatmap_behavior.rb
@@ -15,12 +15,17 @@ module BlacklightHeatmaps
       if blacklight_params[:bbox]
         solr_parameters['facet.heatmap'] = geometry_field
         solr_parameters['facet.heatmap.geom'] = bbox_as_range
+        solr_parameters['facet.heatmap.distErrPct'] = dist_err_pct
         solr_parameters[:bq] ||= []
         solr_parameters[:bq] << "#{geometry_field}:\"IsWithin(#{bbox_as_envelope})\""
         solr_parameters[:fq] ||= []
         solr_parameters[:fq] << "#{geometry_field}:\"Intersects(#{bbox_as_envelope})\""
       end
       solr_parameters
+    end
+
+    def dist_err_pct
+      blacklight_config.heatmap_distErrPct || 0.15
     end
 
     def geometry_field

--- a/lib/generators/blacklight_heatmaps/install_generator.rb
+++ b/lib/generators/blacklight_heatmaps/install_generator.rb
@@ -13,6 +13,7 @@ module BlacklightHeatmaps
       inject_into_file 'app/controllers/catalog_controller.rb', after: 'configure_blacklight do |config|' do
         "\n    # BlacklightHeatmaps configuration values" \
         "\n    config.geometry_field = :geo_srpt" \
+        "\n    config.heatmap_distErrPct = 0.15 # Default Solr value" \
         "\n    # Basemaps configured include: 'positron', 'darkMatter', 'OpenStreetMap.HOT'" \
         "\n    config.basemap_provider = 'positron'" \
         "\n    config.show.partials.insert(1, :show_leaflet_map)" \

--- a/spec/models/concerns/blacklight_heatmaps/solr_facet_heatmap_behavior_spec.rb
+++ b/spec/models/concerns/blacklight_heatmaps/solr_facet_heatmap_behavior_spec.rb
@@ -32,6 +32,8 @@ describe BlacklightHeatmaps::SolrFacetHeatmapBehavior do
           .to eq :geo_srpt
         expect(subject.add_solr_facet_heatmap(solr_params)['facet.heatmap.geom'])
           .to eq '["1 2" TO "4 3"]'
+        expect(subject.add_solr_facet_heatmap(solr_params)['facet.heatmap.distErrPct'])
+          .to eq 0.15
         expect(subject.add_solr_facet_heatmap(solr_params)[:bq])
           .to include(boost: 'stuff')
         expect(subject.add_solr_facet_heatmap(solr_params)[:bq])


### PR DESCRIPTION
This config allows you to chage the distErrPct which controls the resolution of
returned box count values.

Addresses part of #41
