### PR TITLE
revert custom icon hack, as leaflet-rails has a fix

### DIFF
--- a/app/assets/javascripts/blacklight_heatmaps/icons.js.erb
+++ b/app/assets/javascripts/blacklight_heatmaps/icons.js.erb
@@ -1,7 +1,3 @@
 BlacklightHeatmaps.Icons = {
-  default: new L.Icon({
-    iconUrl: '<%= asset_path 'marker-icon.png'%>',
-    iconRetinaUrl: '<%= asset_path 'marker-icon-2x.png'%>',
-    shadowUrl: '<%= asset_path 'marker-shadow.png'%>'
-  })
+  default: new L.Icon.Default()
 };

--- a/blacklight_heatmaps.gemspec
+++ b/blacklight_heatmaps.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 4.2.6', '< 6'
   s.add_dependency 'blacklight', '~> 6.0'
-  s.add_dependency 'leaflet-rails'
+  s.add_dependency 'leaflet-rails', '~> 1.2.0'
   s.add_dependency 'leaflet-sidebar-rails', '~> 0.1.9'
 
   s.add_development_dependency 'sqlite3'

--- a/blacklight_heatmaps.gemspec
+++ b/blacklight_heatmaps.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 4.2.6', '< 6'
   s.add_dependency 'blacklight', '~> 6.0'
   s.add_dependency 'leaflet-rails', '~> 1.2.0'
-  s.add_dependency 'leaflet-sidebar-rails', '~> 0.1.9'
+  s.add_dependency 'leaflet-sidebar-rails', '~> 0.2'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails', '~> 3.4'

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -555,12 +555,6 @@
    -->
  <uniqueKey>id</uniqueKey>
 
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <defaultSearchField>text</defaultSearchField>
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->


### PR DESCRIPTION
This still allows one to customize the default icon used.. so not technically a revert

Will fix the zooming issue outlined in https://github.com/sul-dlss/exhibits/issues/505

Custom icon hack was intended to fix upstream issue w/ leaflet-rails where package wasn't created correctly.