### PR TITLE
Remove detectRetina option for Leaflet

### DIFF
--- a/app/assets/javascripts/blacklight_heatmaps/basemaps.js
+++ b/app/assets/javascripts/blacklight_heatmaps/basemaps.js
@@ -4,7 +4,6 @@ BlacklightHeatmaps.Basemaps = {
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
       maxZoom: 18,
       worldCopyJump: true,
-      detectRetina: true,
     }
   ),
   positron: L.tileLayer(
@@ -12,7 +11,6 @@ BlacklightHeatmaps.Basemaps = {
       attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
       maxZoom: 18,
       worldCopyJump: true,
-      detectRetina: true,
     }
   ),
   'OpenStreetMap.HOT': L.tileLayer(


### PR DESCRIPTION
Removing this allows me to have all the tests pass locally, on my retina display -- but tell me why this is a bad idea!
I don't know whether `detectRetina` is highly desirable. Another approach could be to change the tests.

(I wrote this on Slack)
There are [tests in the blacklight_heatmaps code](https://github.com/sul-dlss/blacklight_heatmaps/blob/46c0dca82ee66f9281ad041c9e16b77c33291902/spec/features/index_page_map_spec.rb#L9) that look for a specific leaflet tile. These tests pass in CI on Github but fail locally, because those exact tiles (something like `/1/0/0.png`) don't get rendered locally. If I change the tests to reflect the tiles (`/2/0/0.png`) that I do see locally, then the Github tests fail. These tiles are based on the zoom level (`/1/` vs `/2/`), so my conclusion is that the Github test runner is zoomed out one level from what renders locally. 