### PR TITLE
Fix JSON response for Blacklight 8

### DIFF
--- a/app/views/catalog/index.heatmaps.jbuilder
+++ b/app/views/catalog/index.heatmaps.jbuilder
@@ -3,7 +3,12 @@ presenter = Blacklight::JsonPresenter.new(@response, blacklight_config)
 json.response do
   json.docs(presenter.documents) do |document|
     document_presenter = document_presenter(document)
-    json.url search_state.url_for_document(document)
+
+    if Blacklight::VERSION > '8'
+      json.url url_for(search_state.url_for_document(document))
+    else
+      json.url search_state.url_for_document(document)
+    end
     json.title document_presenter.heading
   end
 


### PR DESCRIPTION
After moving Exhibits to Blacklight 8 we were getting 'nesting level too deep' on the fetch