### PR TITLE
Specifically call url_for when building json

### DIFF
--- a/app/views/catalog/index.heatmaps.jbuilder
+++ b/app/views/catalog/index.heatmaps.jbuilder
@@ -3,7 +3,7 @@ presenter = Blacklight::JsonPresenter.new(@response, blacklight_config)
 json.response do
   json.docs(presenter.documents) do |document|
     document_presenter = document_presenter(document)
-    json.url search_state.url_for_document(document)
+    json.url url_for(search_state.url_for_document(document))
     json.title document_presenter.heading
   end
 


### PR DESCRIPTION
In Blacklight 8 return values from `url_for_document` such as `[controller.spotlight, current_exhibit, document]` from Spotlight are causing an infinite loop when building the json. Explicitly calling `url_for` when building the URL fixes this issue.