### PR TITLE
Add role to map element

### DIFF
--- a/app/helpers/blacklight/maps_helper.rb
+++ b/app/helpers/blacklight/maps_helper.rb
@@ -10,6 +10,7 @@ module Blacklight
         class: 'blacklight-heatmaps-index-map',
         id: 'index-map',
         data: index_map_data_attributes,
+        role: 'region',
         'aria-label': t('blacklight.heatmaps.aria-label')
       )
     end

--- a/spec/helpers/blacklight/maps_helper_spec.rb
+++ b/spec/helpers/blacklight/maps_helper_spec.rb
@@ -26,6 +26,7 @@ describe Blacklight::MapsHelper do
         .to have_css '[data-basemap-provider="positron"]'
       expect(helper.index_map_div).to have_css '[data-sidebar-template]'
       expect(helper.index_map_div).to have_css '[data-color-ramp]'
+      expect(helper.index_map_div).to have_css '[role="region"]'
       expect(helper.index_map_div).to have_css '[aria-label="heatmap"]'
     end
   end


### PR DESCRIPTION
SiteImprove flags this otherwise for having an aria-label with no role.